### PR TITLE
mpc85xx: fix typo added in r47676

### DIFF
--- a/target/linux/mpc85xx/base-files/etc/board.d/02_network
+++ b/target/linux/mpc85xx/base-files/etc/board.d/02_network
@@ -17,7 +17,7 @@ tl-wdr4900-v1)
 	ucidef_set_interfaces_lan_wan "eth0.1" "eth0.2"
 	ucidef_add_switch "switch0" "1" "1"
 	ucidef_add_switch_ports "switch0" \
-		"0@eth0" "2:lan:1" "3:lan:2" "4:lan:3" "5:lan:4" "2:wan"
+		"0@eth0" "2:lan:1" "3:lan:2" "4:lan:3" "5:lan:4" "1:wan"
 	;;
 *)
 	ucidef_set_interfaces_lan_wan "eth0" "eth1"


### PR DESCRIPTION
Signed-off-by: Jo-Philipp Wich <jow@openwrt.org>

git-svn-id: svn://svn.openwrt.org/openwrt/trunk@47681 3c298f89-4303-0410-b956-a3cf2f4a3e73