### PR TITLE
malta: board.d: fix typo

### DIFF
--- a/target/linux/malta/base-files/etc/board.d/02_network
+++ b/target/linux/malta/base-files/etc/board.d/02_network
@@ -2,7 +2,7 @@
 
 . /lib/functions/uci-defaults-new.sh
 
-board_config_udpate
+board_config_update
 
 ucidef_set_interface_wan "eth0"
 if [ -d "/sys/class/net/eth1" ]; then


### PR DESCRIPTION
Signed-off-by: Jo-Philipp Wich <jow@openwrt.org>

git-svn-id: svn://svn.openwrt.org/openwrt/trunk@47746 3c298f89-4303-0410-b956-a3cf2f4a3e73